### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/deploy-PPSolution-to-dev.yml
+++ b/.github/workflows/deploy-PPSolution-to-dev.yml
@@ -95,7 +95,7 @@ jobs:
 
     - name: Upload job status file as artifact
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v3.1.1
       with:
         name: job_status
         path: status.json
@@ -109,7 +109,7 @@ jobs:
     steps:
 
     - name: Download artifact job_status
-      uses: actions/download-artifact@v2.0.1
+      uses: actions/download-artifact@v3.0.1
       with:
         name: job_status
       continue-on-error: true

--- a/.github/workflows/deploy-PPSolution-to-prod-ini.yml
+++ b/.github/workflows/deploy-PPSolution-to-prod-ini.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
     - name: 'clone this repo'
-      uses: actions/checkout@v2-beta
+      uses: actions/checkout@v3.1.0
 
     - name: Download artifact
-      uses: dawidd6/action-download-artifact@v2
+      uses: dawidd6/action-download-artifact@v2.24.2
       with:
           github_token: ${{secrets.GITHUB_TOKEN}}
           # Required, workflow file name or ID
@@ -78,7 +78,7 @@ jobs:
 
     - name: Upload job status file as artifact
       if: always()
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3.1.1
       with:
         name: job_status
         path: status.json
@@ -92,7 +92,7 @@ jobs:
     steps:
 
     - name: Download artifact job_status
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v3.0.1
       with:
         name: job_status
       continue-on-error: true

--- a/.github/workflows/deploy-PPSolution-to-prod-ini2.yml
+++ b/.github/workflows/deploy-PPSolution-to-prod-ini2.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
     - name: 'clone this repo'
-      uses: actions/checkout@v2-beta
+      uses: actions/checkout@v3.1.0
 
     - name: Download artifact
-      uses: dawidd6/action-download-artifact@v2
+      uses: dawidd6/action-download-artifact@v2.24.2
       with:
           github_token: ${{secrets.GITHUB_TOKEN}}
           # Required, workflow file name or ID
@@ -78,7 +78,7 @@ jobs:
 
     - name: Upload job status file as artifact
       if: always()
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3.1.1
       with:
         name: job_status
         path: status.json
@@ -92,7 +92,7 @@ jobs:
     steps:
 
     - name: Download artifact job_status
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v3.0.1
       with:
         name: job_status
       continue-on-error: true

--- a/.github/workflows/deploy-PPSolution-to-prod.yml
+++ b/.github/workflows/deploy-PPSolution-to-prod.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
     - name: 'clone this repo'
-      uses: actions/checkout@v2-beta
+      uses: actions/checkout@v3.1.0
 
     - name: Download artifact
-      uses: dawidd6/action-download-artifact@v2
+      uses: dawidd6/action-download-artifact@v2.24.2
       with:
           github_token: ${{secrets.GITHUB_TOKEN}}
           # Required, workflow file name or ID
@@ -88,7 +88,7 @@ jobs:
 
     - name: Upload job status file as artifact
       if: always()
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3.1.1
       with:
         name: job_status
         path: status.json
@@ -102,7 +102,7 @@ jobs:
     steps:
 
     - name: Download artifact job_status
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v3.0.1
       with:
         name: job_status
       continue-on-error: true

--- a/.github/workflows/deploy-PPSolution-to-test-ini.yml
+++ b/.github/workflows/deploy-PPSolution-to-test-ini.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
     - name: 'Clone this repo'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v3.1.0
 
     # Github api create-a-repository-dispatch-event doesn't allow more than 10 properties in the client_payload
     # Hence we are using a request object inside a client_payload to take additional properties.
@@ -121,7 +121,7 @@ jobs:
         run-asynchronously: true
         
     - name: 'Upload the managed solution to artifact'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v3.1.1
       with:
         name: ${{env.SolutionName}}
         path: "${{ env.solutionName }}_managed.zip"
@@ -182,7 +182,7 @@ jobs:
         $jsonString > status.json
     - name: Upload job status file as artifact
       if: always()
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3.1.1.1.1
       with:
         name: job_status
         path: status.json
@@ -196,7 +196,7 @@ jobs:
     steps:
 
     - name: Download artifact job_status
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v3.0.1
       with:
         name: job_status
       continue-on-error: true

--- a/.github/workflows/deploy-PPSolution-to-test.yml
+++ b/.github/workflows/deploy-PPSolution-to-test.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
     - name: 'Clone this repo'
-      uses: actions/checkout@v2-beta
+      uses: actions/checkout@v3.1.0
 
     # Github api create-a-repository-dispatch-event doesn't allow more than 10 properties in the client_payload
     # Hence we are using a request object inside a client_payload to take additional properties.
@@ -134,7 +134,7 @@ jobs:
         async: true
 
     - name: 'Upload the managed solution to artifact'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v3.1.1
       with:
         name: ${{env.SolutionName}}
         path: "${{ env.solutionName }}_managed.zip"
@@ -204,7 +204,7 @@ jobs:
 
     - name: Upload job status file as artifact
       if: always()
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3.1.1.1.1
       with:
         name: job_status
         path: status.json
@@ -218,7 +218,7 @@ jobs:
     steps:
 
     - name: Download artifact job_status
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v3.0.1
       with:
         name: job_status
       continue-on-error: true

--- a/.github/workflows/updater.yaml
+++ b/.github/workflows/updater.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.1.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.ALM }}

--- a/.github/workflows/upgrader.yml
+++ b/.github/workflows/upgrader.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.1.0
         with:
           # [Required] Access token with `workflow` scope.
           token: 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


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/download-artifact](https://github.com/actions/download-artifact)** published a new release **[v3.0.1](https://github.com/actions/download-artifact/releases/tag/v3.0.1)** on 2022-10-20T23:34:13Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.1.0](https://github.com/actions/checkout/releases/tag/v3.1.0)** on 2022-10-04T09:40:24Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v3.1.1](https://github.com/actions/upload-artifact/releases/tag/v3.1.1)** on 2022-10-21T19:20:02Z
* **[dawidd6/action-download-artifact](https://github.com/dawidd6/action-download-artifact)** published a new release **[v2.24.2](https://github.com/dawidd6/action-download-artifact/releases/tag/v2.24.2)** on 2022-11-09T16:25:57Z
