### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/deploy-PPSolution-to-test-ini.yml
+++ b/.github/workflows/deploy-PPSolution-to-test-ini.yml
@@ -182,7 +182,7 @@ jobs:
         $jsonString > status.json
     - name: Upload job status file as artifact
       if: always()
-      uses: actions/upload-artifact@v3.1.1.1.1
+      uses: actions/upload-artifact@v3.1.1
       with:
         name: job_status
         path: status.json

--- a/.github/workflows/deploy-PPSolution-to-test.yml
+++ b/.github/workflows/deploy-PPSolution-to-test.yml
@@ -204,7 +204,7 @@ jobs:
 
     - name: Upload job status file as artifact
       if: always()
-      uses: actions/upload-artifact@v3.1.1.1.1
+      uses: actions/upload-artifact@v3.1.1
       with:
         name: job_status
         path: status.json

--- a/.github/workflows/updater.yaml
+++ b/.github/workflows/updater.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.1.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.ALM }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.1.0](https://github.com/actions/checkout/releases/tag/v3.1.0)** on 2022-10-04T09:40:24Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v3.1.1](https://github.com/actions/upload-artifact/releases/tag/v3.1.1)** on 2022-10-21T19:20:02Z
